### PR TITLE
Fix a number of minor style bugs

### DIFF
--- a/client/src/components/ui/scroll-area.tsx
+++ b/client/src/components/ui/scroll-area.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import { createGlobalStyle } from "styled-components";
 
 import { cn } from "../../lib/utils";
 
@@ -43,4 +44,11 @@ const ScrollBar = React.forwardRef<
 ))
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
 
-export { ScrollArea, ScrollBar }
+const ScrollAreaStyles = createGlobalStyle`
+  .scrollarea-fix [data-radix-scroll-area-viewport] > div {
+    display: block !important;
+    min-width: auto !important;
+  }
+`;
+
+export { ScrollArea, ScrollBar, ScrollAreaStyles }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -121,6 +121,10 @@ p, span {
   margin-bottom: 1rem;
 }
 
+.text-break {
+  word-break: break-word;
+}
+
 /* Custom focus states */
 input[name="keyphrase"]:focus {
   outline-color: var(--text3) !important;
@@ -140,4 +144,9 @@ input[name="keyphrase"]:focus-visible {
 input[name="keyphrase"] {
   --tw-ring-color: var(--text3) !important;
   --tw-ring-offset-color: var(--background1) !important;
+}
+
+.scrollarea-fix [data-radix-scroll-area-viewport] > div {
+  display: block !important;
+  min-width: auto !important;
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -879,7 +879,7 @@ export default function Home() {
                 </CardHeader>
                 <CardContent>
                   {selectedCategory ? (
-                    <ScrollArea className="h-[600px] pr-4 w-full">
+                    <ScrollArea className="h-[600px] w-full scrollarea-fix">
                       <motion.div
                         variants={container}
                         initial="hidden"
@@ -932,7 +932,7 @@ export default function Home() {
                                     </Tooltip>
                                   </TooltipProvider>
                                 </motion.div>
-                                <div className="text-sm text-muted-foreground">
+                                <div className="text-sm text-muted-foreground text-break">
                                   <p className="inline">{check.description}</p>
                                   {!check.passed && (
                                     <a 


### PR DESCRIPTION
close 267
There was an auto-generated table styling that was creating some text overflow in some of the categories, especially ones with long file names. This fixed a couple of different Issues, and things look a lot cleaner now.