### PR TITLE
fix: prevent cross-site data contamination in keyword storage

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -501,8 +501,9 @@ export default function Home() {
         const page = await window.webflow.getCurrentPage();
         const publishPath = await page.getPublishPath();
         const isHomepage = await page.isHomepage();
+        const siteInfo = await window.webflow.getSiteInfo();
         
-        const pageId = generatePageId(publishPath, isHomepage);
+        const pageId = generatePageId(publishPath, isHomepage, siteInfo?.siteId);
         setCurrentPageId(pageId);
         
         // Load saved keywords for this page

--- a/client/src/utils/keywordStorage.test.ts
+++ b/client/src/utils/keywordStorage.test.ts
@@ -46,6 +46,18 @@ describe('keywordStorage', () => {
       expect(generatePageId('', false)).toBe('unknown-page');
       expect(generatePageId('/', false)).toBe('homepage');
     });
+
+    it('includes siteId prefix when provided', () => {
+      expect(generatePageId('/', true, 'site123')).toBe('site123::homepage');
+      expect(generatePageId('/about', false, 'site123')).toBe('site123::about');
+      expect(generatePageId(null, false, 'site123')).toBe('site123::unknown-page');
+    });
+
+    it('works without siteId for backward compatibility', () => {
+      expect(generatePageId('/', true, undefined)).toBe('homepage');
+      expect(generatePageId('/about', false, undefined)).toBe('about');
+      expect(generatePageId(null, false, undefined)).toBe('unknown-page');
+    });
   });
 
   describe('saveKeywordsForPage', () => {

--- a/client/src/utils/keywordStorage.ts
+++ b/client/src/utils/keywordStorage.ts
@@ -7,18 +7,22 @@ const STORAGE_KEY = 'webflow-seo-keywords';
 
 /**
  * Generate a unique page identifier from Webflow page data
+ * Now includes siteId to prevent cross-site data contamination
  */
-export function generatePageId(publishPath: string | null, isHomepage: boolean): string {
+export function generatePageId(publishPath: string | null, isHomepage: boolean, siteId?: string): string {
+  const sitePrefix = siteId ? `${siteId}::` : '';
+  
   if (isHomepage) {
-    return 'homepage';
+    return `${sitePrefix}homepage`;
   }
   
   if (!publishPath) {
-    return 'unknown-page';
+    return `${sitePrefix}unknown-page`;
   }
   
   // Clean the publish path to create a consistent ID
-  return publishPath.replace(/^\/+|\/+$/g, '') || 'homepage';
+  const cleanPath = publishPath.replace(/^\/+|\/+$/g, '') || 'homepage';
+  return `${sitePrefix}${cleanPath}`;
 }
 
 /**


### PR DESCRIPTION
- Update generatePageId() to include siteId prefix for proper data isolation
- Site-specific page IDs prevent settings from one website showing on another
- Maintains backward compatibility for existing storage
- Add comprehensive tests for new functionality

Fixes #459